### PR TITLE
Exit straight to `System`

### DIFF
--- a/qbsh.bas
+++ b/qbsh.bas
@@ -192,8 +192,7 @@ Return
 
 'Give a way to close this because this isn't vim
 quit:
-Stop
-End
+System
 
 'A friendly greeting
 WELCOME:


### PR DESCRIPTION
Quits immediately instead of prompting with "Press enter to continue".