### PR TITLE
Add RUN command for invoking qbsh scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright <2021-2022> Scott A. Williams <vwbusguy@fedoraproject.org>
+Copyright <2021-2024> Scott A. Williams <vwbusguy@fedoraproject.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Typing "HELP" (or "help") will bring up a quick list of some command possibiliti
 * `READFILE <file>` - Output some text file to terminal (cat and TYPE also work)
 * `RENAME <File/Dir> <New Name>` - Rename a file or directory (also, MOVE, NAME, or REN)
 * `RMDIR <Directory>` - Delete a directory
+* `RUN <file.qbsh>` - Run a qbsh script from within a script or interactive shell
 * `TIME` - Current time
 * `XDIR <Optional directory>` - List detailed directory info
 * `WHO AM I` - Sometimes we all forget, right? (USER also works)
@@ -72,6 +73,8 @@ qbsh can be scripted using the above commands in a file.  See the examples direc
 `$ qbsh examples/hello.qsh`
 
 Scripts can be padded with empty lines or indents.  To add comments, just begin the line with a single quote (').
+
+Use `RUN` to call a qbsh script from within another qbsh script or interactive shell.
 
 ### Scripting specific commands
 

--- a/qbsh.bas
+++ b/qbsh.bas
@@ -21,13 +21,8 @@ ElseIf InStr(_Trim$(Command$), "-x") = 1 Then
     cmd$ = Right$(_Trim$(Command$), Len(_Trim$(Command$)) - 2)
     GoSub ROUTECMD
 ElseIf _FileExists(_Trim$(Command$)) Then
-    script_mode = True
-    Open _Trim$(Command$) For Input As #5
-    Do Until EOF(5)
-        Line Input #5, cmd$ 'read entire text file line
-        GoSub ROUTECMD
-    Loop
-    Close #5
+    args$ = _Trim$(Command$)
+    GoSub RUNSCRIPT
 Else
     Print "QBSH - Quick BASIC Shell"
     Print
@@ -115,7 +110,7 @@ Return
 CDIR:
 dir$ = resolvePath$(args$)
 If dir$ = "" Then
-	dir$ = Environ$("HOME")
+    dir$ = Environ$("HOME")
 End If
 If _DirExists(dir$) Then
     On Error GoTo CDIRERR
@@ -276,9 +271,9 @@ Return
 'Is there an echo in here?
 OUTCMD:
 If script_mode = True And refcmd$ = "LPRINT" Then
-	Print args$ ;
+    Print args$;
 Else
-	Print args$
+    Print args$
 End If
 Return
 
@@ -473,23 +468,45 @@ Select Case UCase$(refcmd$)
     Case "CLEAR", "CLS": GoSub CLEARSCR
     Case "DATE": Print Date$
     Case "DEVICES": GoSub LSDEV
-    Case "DIR": PRINT listDir$(args$)
+    Case "DIR": Print listDir$(args$)
     Case "ENV": GoSub ENV
     Case "MAKEDIR": GoSub MAKEDIR
     Case "RENAME", "NAME", "MOVE", "REN": GoSub RENAME
     Case "OS": Print _OS$
     Case "PI": Print _Pi
     Case "PIP": GoSub PIP
-    Case "LPRINT","PRINT": GoSub OUTCMD
+    Case "LPRINT", "PRINT": GoSub OUTCMD
     Case "PLAY": GoSub PLAYSOUND
     Case "RAND": GoSub RANDNUM
     Case "RMDIR": GoSub REMDIR
+    Case "RUN": GoSub RUNSCRIPT
     Case "TIME": Print Time$
     Case "USER", "WHO": Print Environ$("USER")
-    Case "XDIR": PRINT listXDir$(args$)
+    Case "XDIR": Print listXDir$(args$)
     Case "READFILE", "CAT", "TYPE": GoSub READFILE
     Case Else: GoSub CMDOUT
 End Select
+Return
+
+RUNSCRIPT:
+If _FileExists(args$) Then
+    On Error GoTo RUNSCRIPTERR
+    Open _Trim$(args$) For Input As #5
+    Do Until EOF(5)
+        script_mode = True
+        Line Input #5, cmd$ 'read entire text file line
+        GoSub ROUTECMD
+    Loop
+    Close #5
+    script_mode = False
+Else
+    Print "Could not open script file at "; args$
+End If
+Return
+
+RUNSCRIPTERR:
+Print "Failed to open/run script at "; args$; ".  Check that the file exists and you have permissions to read it."
+Resume Next
 Return
 
 'Give a way to clo(se this because this isn't vim

--- a/qbsh.bas
+++ b/qbsh.bas
@@ -211,6 +211,7 @@ Print "RAND <Optional Limit> - Random number generator"
 Print "RENAME <File/Dir> <New Name> - Rename a file or directory"
 Print "READFILE <file> - Output some text file to terminal"
 Print "RMDIR <Directory> - Delete a directory"
+Print "RUN <file.qsh> - Run a qbsh script"
 Print "TIME - Current time"
 Print "XDIR <Optional directory> - List detailed directory info"
 Print "WHO AM I - Sometimes we all forget, right?"
@@ -222,6 +223,8 @@ Return
 INIT:
 Randomize Timer
 SELFPATH$ = Environ$("_")
+''Initial increment starting point for script read buffers
+rs% = 5
 If SELFPATH$ = "" Or InStr(SELFPATH$, ".") = 1 Then
     If InStr(Command$(0), ".") = 1 Then
         SELFPATH$ = _CWD$ + "/" + Right$(Command$(0), Len(Command$(0)) - 2)
@@ -479,14 +482,16 @@ Return
 
 RUNSCRIPT:
 If _FileExists(args$) Then
-    Open _Trim$(args$) For Input As #5
-    Do Until EOF(5)
+    rs% = rs% + 1
+    Open _Trim$(args$) For Input As #rs%
+    Do Until EOF(rs%)
         On Error GoTo RUNSCRIPTERR
         script_mode = True
-        Line Input #5, cmd$ 'read entire text file line
+        Line Input #rs%, cmd$ 'read entire text file line
         GoSub ROUTECMD
     Loop
-    Close #5
+    Close #rs%
+    rs% = rs% - 1
     script_mode = False
 Else
     Print "Could not open script file at "; args$

--- a/qbsh.bas
+++ b/qbsh.bas
@@ -23,7 +23,6 @@ ElseIf InStr(_Trim$(Command$), "-x") = 1 Then
 ElseIf _FileExists(_Trim$(Command$)) Then
     args$ = _Trim$(Command$)
     GoSub RUNSCRIPT
-    System
 Else
     Print "QBSH - Quick BASIC Shell"
     Print
@@ -480,12 +479,11 @@ Return
 
 RUNSCRIPT:
 If _FileExists(args$) Then
-    On Error GoTo RUNSCRIPTERR
     Open _Trim$(args$) For Input As #5
     Do Until EOF(5)
+        On Error GoTo RUNSCRIPTERR
         script_mode = True
         Line Input #5, cmd$ 'read entire text file line
-        Print cmd$
         GoSub ROUTECMD
     Loop
     Close #5
@@ -496,7 +494,7 @@ End If
 Return
 
 RUNSCRIPTERR:
-Print "Failed to open/run script at "; args$; " due to"; Err; ".  Check that the file exists and you have permissions to read it."
+Print "Failed to open/run script at "; args$; ".  Check that the file exists and you have permissions to read it."
 Resume Next
 Return
 

--- a/qbsh.bas
+++ b/qbsh.bas
@@ -23,6 +23,7 @@ ElseIf InStr(_Trim$(Command$), "-x") = 1 Then
 ElseIf _FileExists(_Trim$(Command$)) Then
     args$ = _Trim$(Command$)
     GoSub RUNSCRIPT
+    System
 Else
     Print "QBSH - Quick BASIC Shell"
     Print
@@ -185,7 +186,7 @@ Return
 'General Error handler so xmessage doesn't get triggered
 GENERALERROR:
 Print "Something went terribly wrong.  Here's all we know:"
-Print "Error"; Err; "on program file line"; _ErrorLine
+Print "Error "; Err; " on program file line "; _ErrorLine
 Beep
 Resume MAIN
 Return
@@ -484,6 +485,7 @@ If _FileExists(args$) Then
     Do Until EOF(5)
         script_mode = True
         Line Input #5, cmd$ 'read entire text file line
+        Print cmd$
         GoSub ROUTECMD
     Loop
     Close #5
@@ -494,7 +496,7 @@ End If
 Return
 
 RUNSCRIPTERR:
-Print "Failed to open/run script at "; args$; ".  Check that the file exists and you have permissions to read it."
+Print "Failed to open/run script at "; args$; " due to"; Err; ".  Check that the file exists and you have permissions to read it."
 Resume Next
 Return
 

--- a/test.qsh
+++ b/test.qsh
@@ -1,4 +1,3 @@
 #!./qbsh
-
 'Call tests
 RUN ./tests/test.qsh

--- a/test.qsh
+++ b/test.qsh
@@ -1,0 +1,4 @@
+#!./qbsh
+
+'Call tests
+RUN ./tests/test.qsh

--- a/tests/test.qsh
+++ b/tests/test.qsh
@@ -1,4 +1,6 @@
 #!/usr/local/bin/qbsh
+
+'General Tests
 PRINT Starting General Tests
 PRINT =======
 PRINT
@@ -7,6 +9,8 @@ DATE
 LPRINT Time: 
 TIME
 PRINT
+
+'Test Environment
 PRINT * Test Environment
 LPRINT Operating System: 
 OS
@@ -15,20 +19,24 @@ DEVICES
 LPRINT Hello, 
 WHO AM I
 PRINT
+
+'Basic filesystem tests
 PRINT * Changing to home
+CHDIR
 LPRINT Your home: 
 ENV HOME
 PRINT What's in your home:
 DIR
 PRINT What's really in your home:
 XDIR
-CHDIR
 PRINT
 PRINT * Writing a test directory
 MAKEDIR ~/qb64-test
 PRINT * Renaming a test directory
 RENAME qb64-test ~/qb64-test2
 RMDIR ~/qb64-test2
+
+'Calculator Tests
 PRINT * Testing Calculator
 LPRINT 5 - 1 = 
 CALC 5 - 1
@@ -46,6 +54,10 @@ LPRINT 6 r =
 CALC 6 r
 PRINT Can we divide by zero?
 CALC 1 / 0 
+
+'Misc functions
+LPRINT "Dessert: "
+PI
 PRINT Give me two random numbers:
 RAND
 RAND 500

--- a/tests/test.qsh
+++ b/tests/test.qsh
@@ -56,7 +56,7 @@ PRINT Can we divide by zero?
 CALC 1 / 0 
 
 'Misc functions
-LPRINT "Dessert: "
+LPRINT Dessert: 
 PI
 PRINT Give me two random numbers:
 RAND


### PR DESCRIPTION
The RUN command can be invoked from interactive shell or within another qbsh script with the same behavior as starting qbsh with a script file reference.