### PR TITLE
Fix link to qb64.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 QBSH - Quick BASIC Shell
 ========================
 
-This is an attempt at making a command line shell with [QB64](https://www.qb64.com).  Unhandled commands are offloaded to the native shell (bash, etc.).  While it's reached a point of mild sanity, your mileage may vary, so use this at your own risk. 
+This is an attempt at making a command line shell with [QB64](https://qb64.com).  Unhandled commands are offloaded to the native shell (bash, etc.).  While it's reached a point of mild sanity, your mileage may vary, so use this at your own risk. 
 
 Try it with podman or docker:
 


### PR DESCRIPTION
Hi, thanks for the awesome upscale talk. I noticed this link was giving me cert errors on firefox and chrome

https://www.qb64.com redirects to https://qb64.com, but fails cert check when clicked as a link, so link directly to https://qb64.com instead